### PR TITLE
Handle Missing XBox Controller Support Setting

### DIFF
--- a/GlosSITarget/SteamTarget.cpp
+++ b/GlosSITarget/SteamTarget.cpp
@@ -293,7 +293,13 @@ bool SteamTarget::getXBCRebindingEnabled()
     std::ifstream config_file(config_path);
     auto root = tyti::vdf::read(config_file);
 
-    auto xbsup = root.attribs.at("SteamController_XBoxSupport");
+    auto xbsup = std::string("0");
+    try {
+        xbsup = root.attribs.at("SteamController_XBoxSupport");
+    } catch (const std::out_of_range& ex) {
+        // Do nothing as we just didn't find this key in the map
+    }
+    
     if (xbsup != "1") {
         spdlog::warn("\"Xbox Configuration Support\" is disabled in Steam. This may cause doubled Inputs!");
     }


### PR DESCRIPTION
If the "XBox Controller Support" setting has never been touched within Steam the key appears to be missing from the `localconfig.vdf`.

While it can be (and should be) fixed by the user toggling this setting at least once. The application probably shouldn't crash just because it's not there.