### PR TITLE
add `WS_EX_TOOLWINDOW` in extended windows styles for GlosSI-Target

### DIFF
--- a/GlosSITarget/Settings.h
+++ b/GlosSITarget/Settings.h
@@ -54,6 +54,7 @@ inline struct Window {
     int maxFps = 0;
     float scale = 0.f;
     bool disableOverlay = false;
+    bool hideAltTab = false;
 } window;
 
 inline struct Controller {
@@ -189,6 +190,7 @@ inline void Parse(const nlohmann::basic_json<>& json)
             safeParseValue(winconf, "maxFps", window.maxFps);
             safeParseValue(winconf, "scale", window.scale);
             safeParseValue(winconf, "disableOverlay", window.disableOverlay);
+            safeParseValue(winconf, "hideAltTab", window.hideAltTab);
         }
 
         if (auto controllerConf = json["controller"]; !controllerConf.is_null() && !controllerConf.empty() && controllerConf.is_object()) {
@@ -293,6 +295,7 @@ inline nlohmann::json toJson()
     json["window"]["maxFps"] = window.maxFps;
     json["window"]["scale"] = window.scale;
     json["window"]["disableOverlay"] = window.disableOverlay;
+    json["window"]["hideAltTab"] = window.hideAltTab;
     json["controller"]["maxControllers"] = controller.maxControllers;
     json["controller"]["allowDesktopConfig"] = controller.allowDesktopConfig;
     json["controller"]["emulateDS4"] = controller.emulateDS4;

--- a/GlosSITarget/TargetWindow.cpp
+++ b/GlosSITarget/TargetWindow.cpp
@@ -116,13 +116,28 @@ void TargetWindow::setClickThrough(bool click_through)
     }
 #ifdef _WIN32
     HWND hwnd = window_.getSystemHandle();
-    if (click_through) {
-        SetWindowLong(hwnd, GWL_EXSTYLE, WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOPMOST | WS_EX_COMPOSITED);
-        SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+
+    // hiding GlosSI from Alt-Tab list
+    // https://learn.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles
+    if (Settings::window.hideAltTab) {
+        if (click_through) {
+            SetWindowLong(hwnd, GWL_EXSTYLE, WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOPMOST | WS_EX_COMPOSITED | WS_EX_TOOLWINDOW);
+            SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        }
+        else {
+            SetWindowLong(hwnd, GWL_EXSTYLE, WS_EX_LAYERED | WS_EX_COMPOSITED | WS_EX_TOOLWINDOW);
+            SetWindowPos(hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        }
     }
     else {
-        SetWindowLong(hwnd, GWL_EXSTYLE, WS_EX_LAYERED | WS_EX_COMPOSITED);
-        SetWindowPos(hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        if (click_through) {
+            SetWindowLong(hwnd, GWL_EXSTYLE, WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOPMOST | WS_EX_COMPOSITED);
+            SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        }
+        else {
+            SetWindowLong(hwnd, GWL_EXSTYLE, WS_EX_LAYERED | WS_EX_COMPOSITED);
+            SetWindowPos(hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        }
     }
 #endif
 }
@@ -336,11 +351,6 @@ void TargetWindow::createWindow()
     style |= WS_POPUP;
     SetWindowLong(hwnd, GWL_STYLE, style);
     
-    // hiding GlosSI from Alt-Tab list
-    // https://learn.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles
-    auto exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
-    exStyle |= WS_EX_TOOLWINDOW;
-    SetWindowLong(hwnd, GWL_EXSTYLE, exStyle);
 
     MARGINS margins;
     margins.cxLeftWidth = -1;

--- a/GlosSITarget/TargetWindow.cpp
+++ b/GlosSITarget/TargetWindow.cpp
@@ -56,6 +56,11 @@ TargetWindow::TargetWindow(
         if (ImGui::Checkbox("Window mode", &Settings::window.windowMode)) {
             toggle_window_mode_after_frame_ = true;
         }
+#ifdef _WIN32
+        if (ImGui::Checkbox("Hide from Alt+Tab", &Settings::window.hideAltTab)) {
+            toggle_hidealttab_after_frame_ = true;
+        }
+#endif
         ImGui::Text("Max. FPS");
         ImGui::SameLine();
         int max_fps_copy = Settings::window.maxFps;
@@ -120,6 +125,8 @@ void TargetWindow::setClickThrough(bool click_through)
     // hiding GlosSI from Alt-Tab list
     // https://learn.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles
     if (Settings::window.hideAltTab) {
+        toggle_hidealttab_after_frame_ = false;
+
         if (click_through) {
             SetWindowLong(hwnd, GWL_EXSTYLE, WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOPMOST | WS_EX_COMPOSITED | WS_EX_TOOLWINDOW);
             SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
@@ -157,9 +164,15 @@ void TargetWindow::update()
     screenShotWorkaround();
     overlay_->update();
     window_.display();
+#ifdef _WIN32
+    if (toggle_hidealttab_after_frame_) {
+        toggle_hidealttab_after_frame_ = false;
+    }
+#endif
     if (toggle_window_mode_after_frame_) {
         createWindow();
     }
+
     // As SFML screws us out of most windows-events, just poll resolution every once in a while
     // If changed, recreate window.
     // Fixes Blackscreen issues when user does funky stuff and still uses GlosSI in non windowed mod...

--- a/GlosSITarget/TargetWindow.cpp
+++ b/GlosSITarget/TargetWindow.cpp
@@ -336,9 +336,8 @@ void TargetWindow::createWindow()
     style |= WS_POPUP;
     SetWindowLong(hwnd, GWL_STYLE, style);
     
-    auto exStyle = GetWindowLong(hWnd, GWL_EXSTYLE);
     exStyle |= WS_EX_TOOLWINDOW;
-    SetWindowLong(hWnd, GWL_EXSTYLE, exStyle);
+    SetWindowLong(hwnd, GWL_EXSTYLE, exStyle);
 
     MARGINS margins;
     margins.cxLeftWidth = -1;

--- a/GlosSITarget/TargetWindow.cpp
+++ b/GlosSITarget/TargetWindow.cpp
@@ -336,6 +336,9 @@ void TargetWindow::createWindow()
     style |= WS_POPUP;
     SetWindowLong(hwnd, GWL_STYLE, style);
     
+    // hiding GlosSI from Alt-Tab list
+    // https://learn.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles
+    auto exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
     exStyle |= WS_EX_TOOLWINDOW;
     SetWindowLong(hwnd, GWL_EXSTYLE, exStyle);
 

--- a/GlosSITarget/TargetWindow.cpp
+++ b/GlosSITarget/TargetWindow.cpp
@@ -335,6 +335,10 @@ void TargetWindow::createWindow()
     style &= ~WS_OVERLAPPED;
     style |= WS_POPUP;
     SetWindowLong(hwnd, GWL_STYLE, style);
+    
+    auto exStyle = GetWindowLong(hWnd, GWL_EXSTYLE);
+    exStyle |= WS_EX_TOOLWINDOW;
+    SetWindowLong(hWnd, GWL_EXSTYLE, exStyle);
 
     MARGINS margins;
     margins.cxLeftWidth = -1;

--- a/GlosSITarget/TargetWindow.h
+++ b/GlosSITarget/TargetWindow.h
@@ -82,4 +82,5 @@ class TargetWindow {
     void createWindow();
 
     bool toggle_window_mode_after_frame_ = false;
+    bool toggle_hidealttab_after_frame_ = false;
 };


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles

Goal is to remove GlosSI-Target window in Alt-Tab listing as it will induce issues with Steam Link and not particularly intuitive when switching from and to a game.

Currently untested, PR needed only for building a PoC of it and checking for possible issues